### PR TITLE
Get last version of kanso-utils

### DIFF
--- a/node_modules/kanso-utils/attachments.js
+++ b/node_modules/kanso-utils/attachments.js
@@ -20,8 +20,14 @@ var utils = require('./utils'),
  */
 
 exports.add = function (doc, ddoc_path, original_path, content) {
+    if (!(content instanceof Buffer)) {
+        content = new Buffer(content);
+    }
     if (!doc._attachments) {
         doc._attachments = {};
+    }
+    if (doc._attachments[ddoc_path]) {
+        throw new Error('Attachment already exists at ' + ddoc_path);
     }
     doc._attachments[ddoc_path] = {
         'content_type': mime.lookup(original_path),
@@ -70,8 +76,13 @@ exports.addFile = function (pkgdir, p, doc, callback) {
             return callback(err);
         }
         var rel = utils.relpath(p, pkgdir);
-        exports.add(doc, rel, p, content);
-        callback()
+        try {
+            exports.add(doc, rel, p, content);
+        }
+        catch (e) {
+            return callback(e)
+        }
+        callback();
     });
 };
 

--- a/node_modules/kanso-utils/modules.js
+++ b/node_modules/kanso-utils/modules.js
@@ -24,15 +24,28 @@ var utils = require('./utils'),
  * server-side, then add the path to the _modules property for use by the
  * modules plugin postprocessor (when creating the kanso.js attachment)
  *
+ * The filename parameter is optional, and improves error reporting with
+ * line numbers etc.
+ *
  * Returns the updated document.
  *
  * @param {Object} doc
  * @param {String} path
  * @param {String} src
+ * @param {String} filename
  * @returns {Object}
  */
 
-exports.add = function (doc, path, src) {
+exports.add = function (doc, path, src, /*optional*/filename) {
+    if (!doc._module_paths) {
+        doc._module_paths = {};
+    }
+    if (filename) {
+        // Store location of module file for later reference should a
+        // syntax error occur when requiring it.
+        utils.setPropertyPath(doc._module_paths, path, filename);
+    }
+
     var curr = utils.getPropertyPath(doc, path, true);
     if (curr !== undefined) {
         var paths = utils.getPropertyPaths(path, curr);
@@ -111,11 +124,7 @@ exports.addFile = function (pkgdir, p, doc, callback) {
         var rel = utils.relpath(p, pkgdir);
         var module_path = rel.replace(/\.js$/, '');
         var src = content.toString();
-        exports.add(doc, module_path, src);
-        if (!doc._module_paths) {
-            doc._module_paths = {};
-        }
-        utils.setPropertyPath(doc._module_paths, rel, p);
+        exports.add(doc, module_path, src, p);
         callback()
     });
 };
@@ -165,14 +174,16 @@ exports.filenameFilter = function (p) {
 
 
 /**
- * Parses the doc._module_paths object to return an array of filenames
+ * When traversing the document looking for a module, but an object is found
+ * this function will list all sub-paths available under that object - used
+ * to report possible solutions to require path errors.
  */
 
-exports.getFilenames = function (obj) {
+exports.getNames = function (obj) {
     var names = [];
     for (var k in obj) {
         if (typeof obj[k] === 'object') {
-            names.concat(exports.getFilenames(obj[k]).map(function (n) {
+            names.concat(exports.getNames(obj[k]).map(function (n) {
                 return k + '/' + n;
             }));
         }
@@ -221,20 +232,22 @@ exports.require = function (module_cache, doc, current, target, context) {
         return a;
     }, doc);
 
-    var filename = utils.getPropertyPath(
-        doc._module_paths, p.substr(1), true
-    );
+    if (doc._module_paths) {
+        var filename = utils.getPropertyPath(
+            doc._module_paths, p.substr(1), true
+        );
+    }
 
     // if you attempt to require
-    if (typeof filename === 'object') {
-        var filenames = exports.getFilenames(filename);
+    if (typeof content === 'object') {
+        var names = exports.getNames(content);
         throw new Error(
             //'Could not require module: ' + target + ' ' +
             'Could not require module: ' + p.replace(/^\//, '') + ' ' +
             '(from: ' + current.replace(/^\//, '') + ')\n\n' +
             'It\'s not possible to require directories of modules in CouchDB,\n' +
             'you have to specify one of the following sub-modules directly:\n' +
-            filenames.map(function (f) {
+            names.map(function (f) {
                 return '  ' + p.replace(/^\//, '') + '/' + f;
             }).join('\n') + '\n'
         );

--- a/node_modules/kanso-utils/package.json
+++ b/node_modules/kanso-utils/package.json
@@ -1,17 +1,44 @@
 {
-    "name": "kanso-utils",
-    "description": "NPM package which provides some common utility functions used by build-steps in Kanso packages",
-    "maintainers": [
-        {"name": "Caolan McMahon", "web": "https://github.com/caolan"}
-    ],
-    "dependencies": {
-        "async": "0.1.15",
-        "mime": "1.2.4"
+  "name": "kanso-utils",
+  "description": "NPM package which provides some common utility functions used by build-steps in Kanso packages",
+  "maintainers": [
+    {
+      "name": "caolan",
+      "email": "caolan@caolanmcmahon.com"
     },
-    "version": "0.1.3",
-    "repository": {
-        "type": "git",
-        "url": "http://github.com/kanso/kanso-utils.git"
-    },
-    "bugs": {"url": "http://github.com/kanso/kanso-utils/issues"}
+    {
+      "name": "mandric",
+      "email": "mandric@gmail.com"
+    }
+  ],
+  "dependencies": {
+    "async": "0.1.15",
+    "mime": "1.2.4"
+  },
+  "version": "0.1.7",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/kanso/kanso-utils.git"
+  },
+  "bugs": {
+    "url": "http://github.com/kanso/kanso-utils/issues"
+  },
+  "gitHead": "7812c4a614b50156638ca54d84734799cf068928",
+  "homepage": "https://github.com/kanso/kanso-utils",
+  "_id": "kanso-utils@0.1.7",
+  "scripts": {},
+  "_shasum": "2affa0cf24d0a59c7ce52f878359898331c6f3a5",
+  "_from": "kanso-utils@*",
+  "_npmVersion": "1.4.26",
+  "_npmUser": {
+    "name": "mandric",
+    "email": "mandric@gmail.com"
+  },
+  "dist": {
+    "shasum": "2affa0cf24d0a59c7ce52f878359898331c6f3a5",
+    "tarball": "http://registry.npmjs.org/kanso-utils/-/kanso-utils-0.1.7.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/kanso-utils/-/kanso-utils-0.1.7.tgz",
+  "readme": "ERROR: No README data found!"
 }


### PR DESCRIPTION
Getting last version of kanso-utils to fix this issue: https://github.com/kanso/kanso/issues/422
This module is a dependency for several projects and is giving us problems.
